### PR TITLE
chore: bump runtime and perms for gelly and mixtapes

### DIFF
--- a/dev.geopjr.Turntable.yaml
+++ b/dev.geopjr.Turntable.yaml
@@ -34,7 +34,7 @@ finish-args:
   - --filesystem=/var/lib/snapd:ro
   - --filesystem=~/.var/app/com.github.taiko2k.tauonmb/cache/TauonMusicBox/:ro
   - --filesystem=~/.var/app/io.m51.Gelly/cache/io.m51.Gelly/album-art/:ro
-  - --filesystem=~/.var/app/com.pocoguy.Muse/cache/mixtapes/
+  - --filesystem=~/.var/app/com.pocoguy.Muse/cache/mixtapes/:ro
 cleanup:
   - /include
   - /lib/girepository-1.0

--- a/dev.geopjr.Turntable.yaml
+++ b/dev.geopjr.Turntable.yaml
@@ -1,6 +1,6 @@
 app-id: dev.geopjr.Turntable
 runtime: org.gnome.Platform
-runtime-version: '49'
+runtime-version: '50'
 sdk: org.gnome.Sdk
 command: dev.geopjr.Turntable
 finish-args:
@@ -33,6 +33,8 @@ finish-args:
   - --filesystem=xdg-data/applications:ro
   - --filesystem=/var/lib/snapd:ro
   - --filesystem=~/.var/app/com.github.taiko2k.tauonmb/cache/TauonMusicBox/:ro
+  - --filesystem=~/.var/app/io.m51.Gelly/cache/io.m51.Gelly/album-art/:ro
+  - --filesystem=~/.var/app/com.pocoguy.Muse/cache/mixtapes/
 cleanup:
   - /include
   - /lib/girepository-1.0


### PR DESCRIPTION
- GNOME 50 runtime
- perms for gelly and mixtapes mpris art